### PR TITLE
Temporary patch for parser bug

### DIFF
--- a/app/src/main/java/edu/cmu/hcii/sugilite/source_parsing/SugiliteScriptParser.java
+++ b/app/src/main/java/edu/cmu/hcii/sugilite/source_parsing/SugiliteScriptParser.java
@@ -159,15 +159,16 @@ public class SugiliteScriptParser {
         for(SugiliteScriptExpression expression : expressionList){
             //turn each expression to a block
             SugiliteBlock block = expression.toSugiliteBlock(startingBlock, ontologyDescriptionGenerator);
-            if(block instanceof SugiliteStartingBlock) {
-                //contains a starting block
-                startingBlock = (SugiliteStartingBlock) block;
+            if (block != null) {
+                if (block instanceof SugiliteStartingBlock) {
+                    //contains a starting block
+                    startingBlock = (SugiliteStartingBlock) block;
+                } else {
+                    currentBlock.setNextBlock(block);
+                    block.setPreviousBlock(currentBlock);
+                }
+                currentBlock = block;
             }
-            else {
-                currentBlock.setNextBlock(block);
-                block.setPreviousBlock(currentBlock);
-            }
-            currentBlock = block;
         }
         return startingBlock;
     }


### PR DESCRIPTION
NullPointerException when parsing  (SUGILITE_START "order a cappuccino.SugiliteScript") (call click (conj (HAS_PACKAGE_NAME com.google.android.googlequicksearchbox) (hasText Starbucks) (HAS_CLASS_NAME android.widget.TextView))) (call click (conj (HAS_PACKAGE_NAME com.starbucks.mobilecard) (HAS_CONTENT_DESCRIPTION "Order, tab, 3 of 5") (HAS_CLASS_NAME android.widget.FrameLayout)))